### PR TITLE
improve error message on invalid project name.

### DIFF
--- a/src/main/java/hudson/plugins/redmine/RedmineMetricsCalculator.java
+++ b/src/main/java/hudson/plugins/redmine/RedmineMetricsCalculator.java
@@ -97,7 +97,7 @@ public class RedmineMetricsCalculator {
       }
       return proj;
     }
-    return null;
+    throw new RedmineException("No such project. projectName=" + projectName);
   }
 
   private List<String> getVersionsString(RedmineManager manager, Project proj)

--- a/src/test/java/hudson/plugins/redmine/RedmineMetricsCalculatorTest.java
+++ b/src/test/java/hudson/plugins/redmine/RedmineMetricsCalculatorTest.java
@@ -60,4 +60,25 @@ public class RedmineMetricsCalculatorTest {
         "http://example.com/", "APIKEY", "Example", "v1", "", "");
     assertEquals(1, rmc.calc().size());
   }
+
+  @Test(expected=MetricsException.class)
+  public void testNoSuchProject() throws MetricsException, RedmineException {
+    new NonStrictExpectations() {
+      RedmineManager redmineManager;
+      {
+        redmineManager.getProjects();
+        ArrayList<Project> projects = new ArrayList<Project>();
+        Project p = new Project();
+        p.setId(1);
+        p.setName("Example");
+        projects.add(p);
+        returns(projects);
+      }
+    };
+
+    RedmineMetricsCalculator rmc = new RedmineMetricsCalculator(
+        "http://example.com/", "APIKEY", "NoSuchProject", "v1", "", "");
+    rmc.calc();
+  }
+
 }


### PR DESCRIPTION
- issue

I want to redmine metrics,but following console log.

```
ERROR: Publisher hudson.plugins.redmine.RedmineMetricsPublisher aborted due to exception
java.lang.NullPointerException
        at hudson.plugins.redmine.RedmineMetricsCalculator.getVersionsString(RedmineMetricsCalculator.java:105)
        at hudson.plugins.redmine.RedmineMetricsCalculator.calc(RedmineMetricsCalculator.java:43)
        at hudson.plugins.redmine.RedmineMetricsPublisher.perform(RedmineMetricsPublisher.java:54)
        at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:19)
        at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:804)
        at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:779)
        at hudson.model.Build$BuildExecution.post2(Build.java:183)
        at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:726)
        at hudson.model.Run.execute(Run.java:1568)
        at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:46)
        at hudson.model.ResourceController.execute(ResourceController.java:88)
        at hudson.model.Executor.run(Executor.java:236)
Finished: FAILURE
```

set project identifier, but Redmine plugin needs ProjectName.
I could not understand and confused.
- proposal

avoid NPE and include project name to exception message.
