### PR TITLE
Include project name in redmine link

### DIFF
--- a/src/main/java/hudson/plugins/redmine/RedmineLinkAction.java
+++ b/src/main/java/hudson/plugins/redmine/RedmineLinkAction.java
@@ -19,11 +19,11 @@ public class RedmineLinkAction implements Action {
     }
 
     public String getDisplayName() {
-        return "Redmine";
+        return "Redmine - " + prop.projectName;
     }
 
     public String getUrlName() {
-        return prop.redmineWebsite;
+        return prop.redmineWebsite + "projects/" + prop.projectName;
     }
     
 }


### PR DESCRIPTION
Hi,

This is small fix to include project name in redmine link in left panel on project page in jenkins.
