### PR TITLE
allow empty version

### DIFF
--- a/src/main/java/hudson/plugins/redmine/RedmineProjectProperty.java
+++ b/src/main/java/hudson/plugins/redmine/RedmineProjectProperty.java
@@ -93,8 +93,7 @@ public class RedmineProjectProperty extends JobProperty<AbstractProject<?, ?>> {
 			CollectionUtils.filter(redmineSites, new Predicate() {
 				public boolean evaluate(Object object) {
 					return StringUtils.isNotBlank(((RedmineWebsiteConfig) object).name) 
-							&& StringUtils.isNotBlank(((RedmineWebsiteConfig) object).baseUrl) 
-							&& StringUtils.isNotBlank(((RedmineWebsiteConfig) object).versionNumber);
+							&& StringUtils.isNotBlank(((RedmineWebsiteConfig) object).baseUrl);
 				}
 			});
 			CollectionUtils.filter(redmineSites, new Predicate() {

--- a/src/main/java/hudson/plugins/redmine/RedmineWebsiteConfig.java
+++ b/src/main/java/hudson/plugins/redmine/RedmineWebsiteConfig.java
@@ -59,7 +59,11 @@ public class RedmineWebsiteConfig extends AbstractDescribableImpl<RedmineWebsite
 
         public FormValidation doCheckVersionNumber(@QueryParameter String versionNumber) {
         	if (versionNumber == null || versionNumber.trim().length() < 1) {
-        		return FormValidation.error("Version number can't be empty!");
+        		return FormValidation.ok();
+        	}
+        	
+        	if (versionNumber.split("\\.").length != 3) {
+        		return FormValidation.error("Version number must be X.Y.Z form!");
         	}
         	
         	return FormValidation.ok();

--- a/src/main/resources/hudson/plugins/redmine/RedmineWebsiteConfig/config.jelly
+++ b/src/main/resources/hudson/plugins/redmine/RedmineWebsiteConfig/config.jelly
@@ -5,7 +5,7 @@
 	<f:entry field="baseUrl" title="${%Base url}">
 		<f:textbox />
 	</f:entry>
-	<f:entry field="versionNumber" title="${%Version number}">
+	<f:entry field="versionNumber" title="${%Version number}" help="/plugin/redmine/help-version.html">
 		<f:textbox />
 	</f:entry>
 	


### PR DESCRIPTION
empty version setting is prohibited after merge of https://github.com/jenkinsci/redmine-plugin/pull/8
version setting is prepared for compatibilty with old redmine, so many users would not care
