### PR TITLE
Fix for #JENKINS-18110

### DIFF
--- a/src/main/java/hudson/plugins/redmine/RedmineMetricsCalculator.java
+++ b/src/main/java/hudson/plugins/redmine/RedmineMetricsCalculator.java
@@ -97,10 +97,9 @@ public class RedmineMetricsCalculator {
 
   private Project getProject(RedmineManager manager) throws RedmineException {
     for (Project proj : manager.getProjects()) {
-      if (!projectName.equals(proj.getName())) {
-        continue;
+      if (projectName.equals(proj.getName()) || projectName.equals(proj.getIdentifier())) {
+        return proj;
       }
-      return proj;
     }
     throw new RedmineException("No such project. projectName=" + projectName);
   }


### PR DESCRIPTION
Check for both project name and project identifier when looking for a project.

I've kept the check for _both_ name and identifier, but probably only the identifier should be used.  Removing name will break stuff for the people using the workaround though.

(this is basically the same fix that Alex Muthmann did, but this one is hopefully easier to accept).


Eivind